### PR TITLE
Fix: Mejora la responsividad de la tabla de solicitudes del cliente

### DIFF
--- a/assets/css/maps.css
+++ b/assets/css/maps.css
@@ -846,11 +846,11 @@ input.flatpickr-input.form-control { /* Flatpickr might add its own class to the
 /* Estilos responsivos para la tabla de solicitudes del cliente */
 @media (max-width: 768px) {
     .cachilupi-client-requests-panel table.widefat thead {
-        display: none;
+        display: none !important;
     }
 
     .cachilupi-client-requests-panel table.widefat tr {
-        display: block;
+        display: block !important;
         margin-bottom: var(--margin-medium, 15px);
         border: 1px solid var(--border-color-light, #ddd);
         padding: var(--padding-standard, 10px);
@@ -859,13 +859,16 @@ input.flatpickr-input.form-control { /* Flatpickr might add its own class to the
     }
 
     .cachilupi-client-requests-panel table.widefat td {
-        display: block;
+        display: block !important;
+        width: 100% !important;
+        box-sizing: border-box !important;
         text-align: right;
-        padding-left: 50%;
+        padding-left: 50%; /* This will be adjusted by specific needs based on td::before */
         position: relative;
         border-bottom: 1px solid var(--border-color-light, #eee);
         padding-top: var(--padding-standard, 10px);
         padding-bottom: var(--padding-standard, 10px);
+        overflow-wrap: break-word; /* Help prevent overflow from long text */
     }
     .cachilupi-client-requests-panel table.widefat td:last-child {
         border-bottom: none;


### PR DESCRIPTION
Apliqué correcciones a los estilos CSS en `assets/css/maps.css` para asegurar que la tabla "Mis Solicitudes de Servicio" sea completamente responsiva y no cause desbordamiento horizontal en pantallas pequeñas.

Cambios Específicos:
- Reforcé las reglas CSS dentro de la media query `@media (max-width: 768px)` para la tabla `.cachilupi-client-requests-panel table.widefat`.
- Utilicé `!important` en propiedades clave como `display: block` para `tr` y `td`, y `display: none` para `thead`, para garantizar que estos estilos responsivos prevalezcan sobre otros posibles conflictos.
- Establecí `width: 100% !important` y `box-sizing: border-box !important` para las celdas (`td`) en el modo responsivo, asegurando que ocupen el ancho disponible y se apilen correctamente.
- Añadí `overflow-wrap: break-word;` a las celdas (`td`) para mejorar el manejo de texto largo e indivisible, previniendo que este rompa el layout.

Estos cambios aseguran que la tabla se transforme en un formato de "tarjetas" apiladas verticalmente en dispositivos móviles, eliminando la necesidad de scroll horizontal y mejorando la usabilidad.