### PR TITLE
Fix: Correct TypeError in Shortcodes and Review Dynamic Properties

### DIFF
--- a/public/class-cachilupi-pet-shortcodes.php
+++ b/public/class-cachilupi-pet-shortcodes.php
@@ -230,7 +230,9 @@ class Cachilupi_Pet_Shortcodes {
 	 */
 	public function render_client_booking_form_shortcode() {
 		$user = wp_get_current_user();
-		if ( ! is_user_logged_in() || ! array_intersect( array( 'client', 'administrator', 'driver' ), (array) $user->roles, true ) ) {
+		// Corrected condition:
+		// Deny access if user is not logged in, OR if they are logged in but don't have any of the allowed roles.
+		if ( ! is_user_logged_in() || empty( array_intersect( array( 'client', 'administrator', 'driver' ), (array) $user->roles ) ) ) {
 			return '<p>' . esc_html__( 'Debes iniciar sesión como cliente o conductor para solicitar un servicio.', 'cachilupi-pet' ) . '</p>';
 		}
 


### PR DESCRIPTION
This commit includes:
1.  Correction of a TypeError in `Cachilupi_Pet_Shortcodes::render_client_booking_form_shortcode` by modifying the usage of `array_intersect` for role validation. The condition now correctly uses `empty(array_intersect(...))` to check if a user has the required roles.
2.  A review of `Cachilupi_Pet_Plugin` concerning dynamic properties. My analysis concluded that, based on the current code structure, only `$user_roles_manager` is an instance property and was already declared. Other manager classes are instantiated as local variables within the `init()` method. If "dynamic property" warnings persist for you, further investigation in your specific environment focusing on `Cachilupi_Pet_Plugin` (around line 32 as per previous error logs) would be needed.

I attempted to implement class autoloading but faced persistent technical difficulties. This step is highly recommended to be implemented manually to improve code clarity by removing explicit `require_once` statements.

This commit builds upon my previous major backend refactoring efforts.