### PR TITLE
Fix: Corrige error de Parcel eliminando entrada 'main' de package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "cachilupi-pet",
   "version": "1.0.0",
   "description": "Plugin para gestionar servicios de transporte de mascotas con seguimiento.",
-  "main": "cachilupi-pet.php",
   "scripts": {
     "dev:maps": "parcel watch assets/js/src/cachilupi-maps-entry.js --dist-dir assets/dist/js --public-url ./",
     "build:maps": "parcel build assets/js/src/cachilupi-maps-entry.js --dist-dir assets/dist/js --public-url ./ --no-source-maps",


### PR DESCRIPTION
Se eliminó la entrada `"main": "cachilupi-pet.php"` del archivo `package.json`. Esta entrada estaba causando que Parcel interpretara incorrectamente el objetivo de la compilación, resultando en el error "Unexpected output file type .php in target 'main'".

Con esta corrección, los scripts de Parcel para compilar los assets de JavaScript deberían ejecutarse sin este error específico.