### PR TITLE
Fix: Corrected import paths in cachilupi-maps-entry.js

### DIFF
--- a/assets/js/src/cachilupi-maps-entry.js
+++ b/assets/js/src/cachilupi-maps-entry.js
@@ -1,7 +1,7 @@
-import { initMap } from './modules/mapService.js';
-import { initBookingForm } from './modules/bookingForm.js';
-import { initClientRequestsDisplay } from './modules/clientRequestsDisplay.js';
-import { initDriverTrackingModal } from './modules/driverTrackingModal.js';
+import { initMap } from './maps/modules/mapService.js';
+import { initBookingForm } from './maps/modules/bookingForm.js';
+import { initClientRequestsDisplay } from './maps/modules/clientRequestsDisplay.js';
+import { initDriverTrackingModal } from './maps/modules/driverTrackingModal.js';
 // uiUtils are typically used by other modules, so direct init might not be needed here
 // unless there are standalone UI elements to initialize from the entry point.
 


### PR DESCRIPTION
I've updated the module import paths within `assets/js/src/cachilupi-maps-entry.js` to correctly point to the `maps/modules/` subdirectory.

This resolves the Parcel resolution error that occurred when trying to compile `cachilupi-maps-entry.js` after the initial modularization.