### PR TITLE
Debug: Añade logging temporal para capacidades de roles

### DIFF
--- a/includes/users/class-cachilupi-pet-user-roles.php
+++ b/includes/users/class-cachilupi-pet-user-roles.php
@@ -56,6 +56,22 @@ class Cachilupi_Pet_User_Roles {
 				)
 			);
 		}
+
+		// Código de depuración TEMPORAL - INICIO
+		$driver_role_debug = get_role('driver');
+		if ($driver_role_debug) {
+			error_log('Cachilupi Pet Debug - Driver Role Capabilities on add_roles: ' . print_r($driver_role_debug->capabilities, true));
+		} else {
+			error_log('Cachilupi Pet Debug - Driver Role NOT FOUND on add_roles.');
+		}
+
+		$client_role_debug = get_role('client');
+		if ($client_role_debug) {
+			error_log('Cachilupi Pet Debug - Client Role Capabilities on add_roles: ' . print_r($client_role_debug->capabilities, true));
+		} else {
+			error_log('Cachilupi Pet Debug - Client Role NOT FOUND on add_roles.');
+		}
+		// Código de depuración TEMPORAL - FIN
 	}
 
 	/**


### PR DESCRIPTION
Se añadió código de depuración temporal al método `Cachilupi_Pet_User_Roles::add_roles()`. Este código utiliza `error_log()` para registrar las capacidades asignadas a los roles 'driver' y 'client' inmediatamente después de su definición.

Esto ayudará a diagnosticar problemas si las capacidades personalizadas no se están aplicando correctamente a los roles después de la activación del plugin.