### PR TITLE
Fix: Asegura la asignación explícita de capacidades a roles existentes

### DIFF
--- a/includes/users/class-cachilupi-pet-user-roles.php
+++ b/includes/users/class-cachilupi-pet-user-roles.php
@@ -40,13 +40,30 @@ class Cachilupi_Pet_User_Roles {
 				)
 			);
 		}
+		// Explicitly add capabilities to the driver role
+		$driver_role = get_role('driver');
+		if ($driver_role) {
+			$driver_capabilities = [
+				'read'                    => true,
+				'manage_trip_status'      => true,
+				'update_trip_location'    => true,
+				'view_pending_requests'   => true,
+				'access_driver_panel'     => true,
+				'access_booking_form'     => true,
+				'submit_pet_request'      => true,
+			];
+			foreach ($driver_capabilities as $cap => $grant) {
+				$driver_role->add_cap($cap, $grant);
+			}
+		}
+
 		// Add 'client' role on plugin activation
 		// Ensure the role is added if it doesn't exist
 		if ( null === get_role( 'client' ) ) {
 			add_role(
 				'client',
 				__( 'Cliente', 'cachilupi-pet' ),
-				array(
+				array( // These are defaults if role is new
 					'read'                      => true,
 					'view_own_trip_location'    => true,
 					'submit_pet_request'        => true,
@@ -55,6 +72,21 @@ class Cachilupi_Pet_User_Roles {
 					'view_own_requests'         => true,
 				)
 			);
+		}
+		// Explicitly add capabilities to the client role
+		$client_role = get_role('client');
+		if ($client_role) {
+			$client_capabilities = [
+				'read'                      => true,
+				'view_own_trip_location'    => true,
+				'submit_pet_request'        => true,
+				'view_own_request_status'   => true,
+				'access_booking_form'       => true,
+				'view_own_requests'         => true,
+			];
+			foreach ($client_capabilities as $cap => $grant) {
+				$client_role->add_cap($cap, $grant);
+			}
 		}
 
 		// Código de depuración TEMPORAL - INICIO


### PR DESCRIPTION
Modifiqué el método `Cachilupi_Pet_User_Roles::add_roles()` para que, después de las llamadas a `add_role()`, se obtengan los objetos de rol 'driver' y 'client' y se añadan explícitamente todas las capacidades personalizadas definidas para ellos utilizando `$role->add_cap('capability_name', true)`.

Esto soluciona un problema donde las nuevas capacidades no se asignaban a roles que ya existían en la base de datos, ya que `add_role()` no actualiza capacidades de roles preexistentes.